### PR TITLE
Change to replace entrezID with gene/accession in CNV bedfiles

### DIFF
--- a/app/bed_generator/bed_generator.py
+++ b/app/bed_generator/bed_generator.py
@@ -43,7 +43,7 @@ class BedGenerator:
         },
         'cnv': {
             'fields': [
-                lambda r, _: str(r['entrez_id'])
+                lambda r, _: f"{r['gene']};{r['accession']}"
             ]
         }
     }


### PR DESCRIPTION
Replaced entrez_id in CNV beds with gene;accession. 

This was tested by performing an exomeDepth reanalysis in run 002_250205_A01229_0452_BHM2MYDRX5_NGS669_NGS_VCP and assessing that the target inputs present in the BED file were present in the exomeDepth output PDF files. 

The following CNV bed file was created with these changes and used as an input:

```
13	32890597	32890664	BRCA2;NM_000059.3
13	32893214	32893462	BRCA2;NM_000059.3
13	32899213	32899321	BRCA2;NM_000059.3
13	32900238	32900287	BRCA2;NM_000059.3
13	32900379	32900419	BRCA2;NM_000059.3
13	32900636	32900750	BRCA2;NM_000059.3
13	32903580	32903629	BRCA2;NM_000059.3
13	32905056	32905167	BRCA2;NM_000059.3
13	32906409	32907524	BRCA2;NM_000059.3
13	32910402	32915333	BRCA2;NM_000059.3
13	32918695	32918790	BRCA2;NM_000059.3
13	32920964	32921033	BRCA2;NM_000059.3
13	32928998	32929425	BRCA2;NM_000059.3
13	32930565	32930746	BRCA2;NM_000059.3
13	32931879	32932066	BRCA2;NM_000059.3
13	32936660	32936830	BRCA2;NM_000059.3
13	32937316	32937670	BRCA2;NM_000059.3
13	32944539	32944694	BRCA2;NM_000059.3
13	32945093	32945237	BRCA2;NM_000059.3
13	32950807	32950928	BRCA2;NM_000059.3
13	32953454	32953652	BRCA2;NM_000059.3
13	32953887	32954050	BRCA2;NM_000059.3
13	32954144	32954282	BRCA2;NM_000059.3
13	32968826	32969070	BRCA2;NM_000059.3
13	32971035	32971181	BRCA2;NM_000059.3
13	32972299	32972908	BRCA2;NM_000059.3
16	23614779	23614990	PALB2;NM_024675.3
16	23619185	23619333	PALB2;NM_024675.3
16	23625325	23625412	PALB2;NM_024675.3
16	23632683	23632799	PALB2;NM_024675.3
16	23634290	23634451	PALB2;NM_024675.3
16	23635330	23635415	PALB2;NM_024675.3
16	23637557	23637718	PALB2;NM_024675.3
16	23640525	23640596	PALB2;NM_024675.3
16	23640961	23641790	PALB2;NM_024675.3
16	23646183	23647655	PALB2;NM_024675.3
16	23649171	23649273	PALB2;NM_024675.3
16	23649391	23649450	PALB2;NM_024675.3
16	23652431	23652479	PALB2;NM_024675.3
17	41197694	41197819	BRCA1;NM_007294.3
17	41199660	41199720	BRCA1;NM_007294.3
17	41201138	41201211	BRCA1;NM_007294.3
17	41203080	41203134	BRCA1;NM_007294.3
17	41209069	41209152	BRCA1;NM_007294.3
17	41215350	41215390	BRCA1;NM_007294.3
17	41215891	41215968	BRCA1;NM_007294.3
17	41219625	41219712	BRCA1;NM_007294.3
17	41222945	41223255	BRCA1;NM_007294.3
17	41226348	41226538	BRCA1;NM_007294.3
17	41228505	41228631	BRCA1;NM_007294.3
17	41234421	41234592	BRCA1;NM_007294.3
17	41242961	41243049	BRCA1;NM_007294.3
17	41243452	41246877	BRCA1;NM_007294.3
17	41247863	41247939	BRCA1;NM_007294.3
17	41249261	41249306	BRCA1;NM_007294.3
17	41251792	41251897	BRCA1;NM_007294.3
17	41256139	41256278	BRCA1;NM_007294.3
17	41256885	41256973	BRCA1;NM_007294.3
17	41258473	41258550	BRCA1;NM_007294.3
17	41267743	41267796	BRCA1;NM_007294.3
17	41276034	41276114	BRCA1;NM_007294.3
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/bedmakerGUI/4)
<!-- Reviewable:end -->
